### PR TITLE
v9.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,45 @@
 {% set name = "pymdown-extensions" %}
-{% set version = "9.9.2" %}
+{% set version = "9.11" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # FIXME:
-  # The above url did not work for version 9.4.
-  # If it works in future it should be used in preference to the GitHub archive url below.
-  url: https://github.com/facelessuser/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 49e26c332a15c724ebf73ee648d7d2ae804dbb84dc671684489229ce3b8d6c73
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pymdown_extensions-{{ version }}.tar.gz
+  sha256: f7e86c1d3981f23d9dc43294488ecb54abadd05b0be4bf8f0e15efc90f7853ff
 
 build:
   number: 0
-  noarch: python
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
+  skip: true  # [py<37]
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - wheel
     - hatchling >=0.21.1
   run:
     - markdown >=3.2
-    - python >=3.7
+    - pyyaml
+    - python
+    # 
+    
 
 test:
+  ## TODO re-enable pytest when pygments >=2.12 is available.
+  # source_files:
+  #   - tests
+  # requires:
+  #   - pip
+  #   - pytest
+  #   - pygments >=2.12
   imports:
     - pymdownx
+  commands:
+    - pip check
+    # - pytest
 
 about:
   home: https://github.com/facelessuser/pymdown-extensions
@@ -37,6 +47,11 @@ about:
   license_family: MIT
   license_file: LICENSE.md
   summary: Extension pack for Python Markdown.
+  description: |
+    PyMdown Extensions is a collection of extensions for Python Markdown. 
+    They were originally written to make writing documentation more enjoyable. 
+    They cover a wide range of solutions, and while not every extension 
+    is needed by all people, there is usually at least one useful extension for everybody.
   doc_url: https://facelessuser.github.io/pymdown-extensions/
   dev_url: https://github.com/facelessuser/pymdown-extensions
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ requirements:
     - markdown >=3.2
     - pyyaml
     - python
-    # 
-    
 
 test:
   ## TODO re-enable pytest when pygments >=2.12 is available.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ test:
   ## TODO re-enable pytest when pygments >=2.12 is available.
   # source_files:
   #   - tests
-  # requires:
-  #   - pip
+  requires:
+    - pip
   #   - pytest
   #   - pygments >=2.12
   imports:


### PR DESCRIPTION
# pymdown-extensions v9.11

`streamlit-extras` -> `markdownlit` -> `pymdown-extensions`

upstream: https://github.com/facelessuser/pymdown-extensions
requirements: https://github.com/facelessuser/pymdown-extensions/blob/main/requirements/project.txt

## Notes
- This feedstock has never been released, this will be the first version available
- For Snowflake
- Tests are currently being skipped because they require the optional dependency `pygments >=2.12` that is currently unavailable
