### PR TITLE
pymdown-extensions 10.21.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pymdown-extensions" %}
-{% set version = "10.16.1" %}
+{% set version = "10.21.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pymdown_extensions-{{ version }}.tar.gz
-  sha256: aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91
+  sha256: 72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354
 
 build:
   number: 0


### PR DESCRIPTION
## pymdown-extensions 10.21.3

**Destination channel:** defaults

### Links
- [PKG-15118](https://anaconda.atlassian.net/browse/PKG-15118)
- [PyPI](https://pypi.org/project/pymdown-extensions/10.21.3/)
- [GitHub release](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.21.3)

### Explanation of changes:
- Updated pymdown-extensions from 10.16.1 to 10.21.3
- No dependency changes (runtime deps unchanged: `markdown >=3.6`, `pyyaml`; optional `pygments >=2.19.1` in `run_constrained`)
- Notable upstream fix: directory traversal regression in snippets when `restrict_base_path` is enabled (default)


Made with [Cursor](https://cursor.com)

[PKG-15118]: https://anaconda.atlassian.net/browse/PKG-15118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ